### PR TITLE
Only add the comment for no id if the comment does not already exist

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -2338,8 +2338,7 @@ function run() {
             }
             const pivotalId = utils_1.getPivotalId(headBranch);
             if (!pivotalId) {
-                const comment = Object.assign(Object.assign({}, commonPayload), { body: utils_1.getNoIdComment(headBranch) });
-                yield utils_1.addComment(client, comment);
+                yield utils_1.addNoIdComment(client, headBranch, commonPayload);
                 core.setFailed('Pivotal id is missing in your branch.');
                 process.exit(1);
             }
@@ -2378,8 +2377,7 @@ function run() {
                 }
             }
             else {
-                const comment = Object.assign(Object.assign({}, commonPayload), { body: utils_1.getNoIdComment(headBranch) });
-                yield utils_1.addComment(client, comment);
+                yield utils_1.addNoIdComment(client, headBranch, commonPayload);
                 core.setFailed('Invalid pivotal story id. Please create a branch with a valid pivotal story');
                 process.exit(1);
             }
@@ -2900,6 +2898,27 @@ const getStoryIcon = (storyType) => {
             return '';
     }
 };
+/**
+ * Helpful function to add a comment that we couldn't find the Pivotal ID
+ * of this comment. Will attempt to only add once.
+ */
+exports.addNoIdComment = (client, branch, params) => __awaiter(void 0, void 0, void 0, function* () {
+    const { data: comments } = yield client.issues.listComments(params);
+    const noIdComment = exports.getNoIdComment(branch);
+    // Find a previously created comment by our bot
+    const previousComments = comments.filter(comment => comment.body.includes(noIdComment));
+    if (previousComments.length > 0) {
+        // Update existing comment
+        const { id } = previousComments[0];
+        console.log(`Comment already exists as comment #${id}`);
+    }
+    else {
+        // Insert a new comment
+        console.log('Adding a new comment');
+        const comment = Object.assign(Object.assign({}, params), { body: noIdComment });
+        yield exports.addComment(client, comment);
+    }
+});
 /**
  * Returns true if the body contains the hidden marker. Used to avoid adding
  * pivotal story details to the PR multiple times.

--- a/src/main.ts
+++ b/src/main.ts
@@ -18,7 +18,7 @@ import {
   getPrTitleComment,
   getHugePrComment,
   isHumongousPR,
-  getNoIdComment,
+  addNoIdComment,
   shouldAddComments,
 } from './utils';
 import { PullRequestParams, PivotalDetails } from './types';
@@ -96,11 +96,7 @@ async function run() {
 
     const pivotalId = getPivotalId(headBranch);
     if (!pivotalId) {
-      const comment: IssuesCreateCommentParams = {
-        ...commonPayload,
-        body: getNoIdComment(headBranch),
-      };
-      await addComment(client, comment);
+      await addNoIdComment(client, headBranch, commonPayload);
 
       core.setFailed('Pivotal id is missing in your branch.');
       process.exit(1);
@@ -159,11 +155,7 @@ async function run() {
         }
       }
     } else {
-      const comment: IssuesCreateCommentParams = {
-        ...commonPayload,
-        body: getNoIdComment(headBranch),
-      };
-      await addComment(client, comment);
+      await addNoIdComment(client, headBranch, commonPayload);
 
       core.setFailed('Invalid pivotal story id. Please create a branch with a valid pivotal story');
       process.exit(1);


### PR DESCRIPTION
Hey,

We have a few cases where having no id is sort of ok (temporary branches, hacking around, sharing an idea quickly), and at the moment every time we push to that branch, we get a new comment.

This stops the comment from being added if it already exists. 

Thanks!